### PR TITLE
fix: replace i-d-template build in publish.yml with build.sh

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,9 +40,12 @@ jobs:
         restore-keys: i-d-
 
     - name: "Build Drafts"
-      uses: martinthomson/i-d-template@v1
-      with:
-        token: ${{ github.token }}
+      run: |
+        ./build.sh
+        mkdir -p versioned
+        for f in draft-*.xml draft-*.txt draft-*.html; do
+          [ -f "$f" ] && cp "$f" versioned/
+        done
 
     - name: "Upload to Datatracker"
       uses: martinthomson/i-d-template@v1


### PR DESCRIPTION
Fixes lint-docname failures when docname uses explicit version numbers (-02). Stages versioned/ directory so make upload can submit to Datatracker.