### PR TITLE
fix: restore docnames to -latest and revert ghpages.yml to template

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -35,24 +35,22 @@ jobs:
           .refcache
           .venv
           .gems
+          node_modules
+          .targets.mk
         key: i-d-${{ steps.setup.outputs.date }}
         restore-keys: i-d-
 
     - name: "Build Drafts"
-      run: ./build.sh
-
-    - name: "Stage GitHub Pages"
-      if: ${{ github.event_name == 'push' }}
-      run: mkdir -p /tmp/pages && cp draft-*.html draft-*.txt /tmp/pages/
+      uses: martinthomson/i-d-template@v1
+      with:
+        token: ${{ github.token }}
 
     - name: "Update GitHub Pages"
+      uses: martinthomson/i-d-template@v1
       if: ${{ github.event_name == 'push' }}
-      uses: peaceiris/actions-gh-pages@v4
       with:
-        github_token: ${{ github.token }}
-        publish_dir: /tmp/pages
-        keep_files: true
-        commit_message: "Update editor's copy [ci skip]"
+        make: gh-pages
+        token: ${{ github.token }}
 
     - name: "Archive Built Drafts"
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Set both docnames back to `-latest` as required by i-d-template lint-docname\n- Revert ghpages.yml to the unmodified i-d-template original\n- Version numbers are assigned from git tags by the CI pipeline