### PR TITLE
fix: restore docnames to -latest

### DIFF
--- a/draft-mpsb-agntcy-messaging.md
+++ b/draft-mpsb-agntcy-messaging.md
@@ -3,7 +3,7 @@ title: "An Overview of Messaging Systems and Their Applicability to Agentic AI"
 abbrev: "agntcy-messaging-eco"
 category: info
 
-docname: draft-mpsb-agntcy-messaging-02
+docname: draft-mpsb-agntcy-messaging-latest
 submissiontype: independent
 number:
 date: 2026-07-07

--- a/draft-mpsb-agntcy-slim.md
+++ b/draft-mpsb-agntcy-slim.md
@@ -3,7 +3,7 @@ title: "Secure Low-Latency Interactive Messaging (SLIM)"
 abbrev: "agent-slim"
 category: info
 
-docname: draft-mpsb-agntcy-slim-02
+docname: draft-mpsb-agntcy-slim-latest
 submissiontype: independent
 number:
 date: 2026-07-07


### PR DESCRIPTION
The i-d-template CI requires `docname` to end with `-latest` in the source files. Version numbers (e.g. `-02`) are assigned automatically by the publish pipeline from git tags.\n\nThis restores both docnames so the CI passes.